### PR TITLE
fix for proxy / no_proxy handling

### DIFF
--- a/ckanext/sparql/plugin.py
+++ b/ckanext/sparql/plugin.py
@@ -53,8 +53,14 @@ def sparqlQuery(data_structure):
     }
     
     querypart = urllib.urlencode(params_query)
-    temp_result = urllib.urlopen(request.params.get('server'),querypart)
+    log.debug("querypart: " + querypart)
+
+    server = request.params.get('server')
+    log.debug("server: " + server)
+
+    temp_result = urllib.urlopen(server, querypart)
     response_query = temp_result.read()
+    log.debug("response_query: " + response_query)
     
     if request.params.get('type_response_query') == 'json': 
         data=json.loads(response_query, object_pairs_hook=collections.OrderedDict)
@@ -117,14 +123,14 @@ def check_is_url(strtocheck):
     return results.scheme
 
 def endpoint_url():
-	endpointUrl = config.get('ckanext.sparql.endpoint_url', 'http://dbpedia.org/sparql')
-	#log.debug("endpointUrl: " + endpointUrl)
-	return endpointUrl
+    endpointUrl = config.get('ckanext.sparql.endpoint_url', 'http://dbpedia.org/sparql')
+    #log.debug("endpointUrl: " + endpointUrl)
+    return endpointUrl
 
 def hide_endpoint_url():
-	hideEndpointUrl = p.toolkit.asbool(config.get('ckanext.sparql.hide_endpoint_url', 'False'))
-	#log.debug("hideEndpointUrl: %s" % hideEndpointUrl)
-	return hideEndpointUrl
+    hideEndpointUrl = p.toolkit.asbool(config.get('ckanext.sparql.hide_endpoint_url', 'False'))
+    #log.debug("hideEndpointUrl: %s" % hideEndpointUrl)
+    return hideEndpointUrl
 
 ### CLASS ###
 

--- a/ckanext/sparql/plugin.py
+++ b/ckanext/sparql/plugin.py
@@ -2,7 +2,7 @@ from logging import getLogger
 import ckan.plugins as p
 from pylons import request, response, config
 #from SPARQLWrapper import SPARQLWrapper, JSON
-import urllib, json
+import urllib, urllib2, json
 import collections
 from urlparse import urlparse
 import csv
@@ -58,7 +58,7 @@ def sparqlQuery(data_structure):
     server = request.params.get('server')
     log.debug("server: " + server)
 
-    temp_result = urllib.urlopen(server, querypart)
+    temp_result = urllib2.urlopen(server, querypart)
     response_query = temp_result.read()
     log.debug("response_query: " + response_query)
     


### PR DESCRIPTION
We rushed into a problem with ckanext-sparql when http_proxy / no_proxy settings are in place on the ckan host. (e.g. [1]). `no_proxy` environment setting was not honored and hence sparql query failed. 

Similar bugs have been reported for urllib and urllib2 ([2], [3]). However, it seams to have been fixed in urllib2 as both proxy and no_proxy settings work for us with this change. 

[1] https://bugzilla.redhat.com/show_bug.cgi?id=132477
[2] https://github.com/ckan/ckan/issues/1213
[3] http://www.decalage.info/en/python/urllib2noproxy
